### PR TITLE
Fixed bug when passing dates from the tkcalendar widget to database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 build
 dist/AID
+test*

--- a/AID.spec
+++ b/AID.spec
@@ -9,7 +9,7 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=[],
-    hiddenimports=['babel.numbers'],
+    hiddenimports=[],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -41,5 +41,4 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon='AFFCO Provisions Logo Symbol.ico',
 )

--- a/aid_import.py
+++ b/aid_import.py
@@ -44,6 +44,7 @@ def aid_import(treeview, root, conn):
     # Initialize variables for con, import files, & desktop path 
     create_table(conn)
     paths = select_files()
+    paths = sorted(paths)
     desktop_path = os.path.join(os.path.expanduser("~"), "Desktop")
 
     # Initialize most recent sell bys

--- a/aid_import_def.py
+++ b/aid_import_def.py
@@ -96,7 +96,7 @@ def deliv_date(conn, df, root):
 
     # Prompt user for the delivery date, transform to datetime
     new_date = deldate_cal_win(df, root)
-    new_date = pd.to_datetime(new_date)
+    new_date = pd.to_datetime(new_date, format='%Y-%m-%d')
     
     # Get a list of all delivery numbers from the database
     existing_del_num = pd.read_sql_query('SELECT delivery_number FROM delivery_date', conn)['Delivery_Number'].values
@@ -124,19 +124,21 @@ def deldate_cal_win(df, root):
     # Prompt user to select the delivery date of the incoming invoice
     root = tk.Toplevel()
     root.title(f"Delivery date from invoice {invoice_num(df)}")
+    root.geometry("400x225")
 
     mainframe = Frame(root)
     mainframe.pack()
 
     chosen_date = StringVar()
-    choose_date = StringVar(value=datetime.now().strftime('%d/%m/%Y'))
-    new_date_cal = Calendar(mainframe, date_pattern='y/mm/dd', textvariable=choose_date)
+    choose_date = StringVar(value=datetime.now().strftime('%Y-%m-%d'))
+    new_date_cal = Calendar(mainframe, date_pattern='y-mm-dd', textvariable=choose_date)
     new_date_cal.pack()
 
-    button = Button(mainframe, text="OK", command=return_date)
+    button = Button(mainframe, text="OK", command=lambda:return_date())
     button.pack(fill=BOTH)
 
     mainframe.focus_force()
+    root.wait_window()
 
     return chosen_date.get()
 

--- a/db_query.py
+++ b/db_query.py
@@ -5,7 +5,8 @@ from datetime import datetime
 import babel.numbers
 
 def connection():
-    db_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'invoice_db.db')
+    home_dir = os.path.expanduser("~")
+    db_path = os.path.join(home_dir, "AID\invoice_db.db")
     print(db_path)
     return sqlite3.connect(db_path)
 


### PR DESCRIPTION
* Added .gitignore because I forgot
* Broke up creating connection object to facilitate debugging
* Tkcalendar now properly passes date from itself to the parent function.
* Standardized dates for delivery_date table
* Added sorting & widget resize for mass import